### PR TITLE
fix: mvmap command works for mitre_technique_id

### DIFF
--- a/default/props.conf
+++ b/default/props.conf
@@ -19,10 +19,9 @@ EVAL-src = case(category=="AdvancedHunting-DeviceNetworkEvents", 'properties.Loc
 EVAL-file_path = case(category IN ("AdvancedHunting-DeviceFileEvents", "AdvancedHunting-AlertEvidence"),'properties.FolderPath')
 
 # Alerts node
-# Does not work. Bug SPL-205994 to be fixed in 8.3.0
-# Error in 'eval' command: The arguments to the 'mvmap' function are invalid.
-#EVAL-mitre_technique_id = mvmap(json_array_to_mv('properties.AttackTechniques'), replace('properties.AttackTechniques', "(.+)\((\S+)\)$", "\2"))
-# mitre_technique_name is not a CIM field, but useful perhaps
+EVAL-mitre_technique_id = mvmap(json_array_to_mv('properties.AttackTechniques'), replace('properties.AttackTechniques', "(.+)\((\S+)\)$", "\2"))
+# mitre_technique_name and description are not a CIM fields, but useful perhaps
+EVAL-mitre_technique_description = mvmap(json_array_to_mv('properties.AttackTechniques'), replace('properties.AttackTechniques', "(.+)\((\S+)\)$", "\1"))
 EVAL-mitre_technique_name = json_array_to_mv('properties.AttackTechniques')
 EVAL-id = case(category IN ("AdvancedHunting-DeviceAlertEvents", "AdvancedHunting-AlertInfo", "AdvancedHunting-AlertEvidence"), 'properties.AlertId', 1==1, null())
 EVAL-severity = case(category IN ("AdvancedHunting-DeviceAlertEvents", "AdvancedHunting-AlertInfo", "AdvancedHunting-AlertEvidence"), lower('properties.Severity'), 1==1, null())
@@ -123,10 +122,9 @@ EVAL-src = case(category=="AdvancedHunting-DeviceNetworkEvents", 'properties.Loc
 EVAL-file_path = case(category IN ("AdvancedHunting-DeviceFileEvents", "AdvancedHunting-AlertEvidence"),'properties.FolderPath')
 
 # Alerts node
-# Does not work. Bug SPL-205994 to be fixed in 8.3.0
-# Error in 'eval' command: The arguments to the 'mvmap' function are invalid.
-#EVAL-mitre_technique_id = mvmap(json_array_to_mv('properties.AttackTechniques'), replace('properties.AttackTechniques', "(.+)\((\S+)\)$", "\2"))
-# mitre_technique_name is not a CIM field, but useful perhaps
+EVAL-mitre_technique_id = mvmap(json_array_to_mv('properties.AttackTechniques'), replace('properties.AttackTechniques', "(.+)\((\S+)\)$", "\2"))
+# mitre_technique_name and description are not a CIM fields, but useful perhaps
+EVAL-mitre_technique_description = mvmap(json_array_to_mv('properties.AttackTechniques'), replace('properties.AttackTechniques', "(.+)\((\S+)\)$", "\1"))
 EVAL-mitre_technique_name = json_array_to_mv('properties.AttackTechniques')
 EVAL-id = case(category IN ("AdvancedHunting-DeviceAlertEvents", "AdvancedHunting-AlertInfo", "AdvancedHunting-AlertEvidence"), 'properties.AlertId', 1==1, null())
 EVAL-severity = case(category IN ("AdvancedHunting-DeviceAlertEvents", "AdvancedHunting-AlertInfo", "AdvancedHunting-AlertEvidence"), lower('properties.Severity'), 1==1, null())


### PR DESCRIPTION
Tested and verified `mvmap` works in Splunk Cloud 8.2.2109. Needs to be tested for Enterprise.